### PR TITLE
Add detection for CPU model 69 (Haswell ix-4xxxU)

### DIFF
--- a/cmake/OptimizeForArchitecture.cmake
+++ b/cmake/OptimizeForArchitecture.cmake
@@ -71,7 +71,9 @@ macro(AutodetectHostArchitecture)
    if(_vendor_id STREQUAL "GenuineIntel")
       if(_cpu_family EQUAL 6)
          # Any recent Intel CPU except NetBurst
-         if(_cpu_model EQUAL 62)
+         if(_cpu_model EQUAL 69)    # Core i5/i7-4xxxU CPUs
+            set(TARGET_ARCHITECTURE "haswell")
+         elseif(_cpu_model EQUAL 62)
             set(TARGET_ARCHITECTURE "ivy-bridge")
          elseif(_cpu_model EQUAL 60)
             set(TARGET_ARCHITECTURE "haswell")


### PR DESCRIPTION
_i5-4200U_ and _i7-4500U_ (and possibly more) are model 69, which previously was not detected properly, which triggered a fallback to optimisations core 2 which apparently fails to compile due to conflicting definitions of intrinsics.

I did not investigate the resulting conflicts further, but they seem to imply that something else is already correctly defining the intrinsics and the fallback tries to redefine them.
