### PR TITLE
Fix segfault when refreshing render window

### DIFF
--- a/src/editor/RenderWindow.cpp
+++ b/src/editor/RenderWindow.cpp
@@ -201,7 +201,7 @@ void RenderWindow::finishRender()
 
 void RenderWindow::refresh()
 {
-    if (!_image)
+    if (!_image || !_renderer)
         return;
 
     uint32 w = _image->width(), h = _image->height();


### PR DESCRIPTION
When not rendering, hitting F5 would produce a segmentation fault, as _pixels would be empty but accessed anyway.
