### PR TITLE
Allow setup_builds.sh to be run from anywhere

### DIFF
--- a/setup_builds.sh
+++ b/setup_builds.sh
@@ -8,6 +8,8 @@ if [[ -n "$*" ]];
 then
     GENERATOR=(-G "$*")
 fi
+
+ROOTDIR="$(dirname "$(readlink -fn "$0")")"
     
 rm -rf build
 mkdir build
@@ -15,9 +17,9 @@ cd build
 
 mkdir release
 cd release
-cmake -DCMAKE_BUILD_TYPE=Release "${GENERATOR[@]}" ../../
+cmake -DCMAKE_BUILD_TYPE=Release "${GENERATOR[@]}" ${ROOTDIR}
 cd ..
 
 mkdir debug
 cd debug
-cmake -DCMAKE_BUILD_TYPE=Debug "${GENERATOR[@]}" ../../
+cmake -DCMAKE_BUILD_TYPE=Debug "${GENERATOR[@]}" ${ROOTDIR}


### PR DESCRIPTION
Instead of assuming that your CWD is the project root, assume that
setup_builds.sh lives in the project root