### PR TITLE
tungsten_server: set context to null after mg_stop

### DIFF
--- a/src/tungsten-server/tungsten-server.cpp
+++ b/src/tungsten-server/tungsten-server.cpp
@@ -157,6 +157,7 @@ int main(int argc, const char *argv[])
     while (renderer->renderScene());
 
     mg_stop(context);
+    context = nullptr;
 
     return 0;
 }


### PR DESCRIPTION
This prevents the atexit handler from trying to call mg_stop a second
time