### PR TITLE
Fix for wrong error message when opening directory

### DIFF
--- a/src/core/io/FileUtils.cpp
+++ b/src/core/io/FileUtils.cpp
@@ -436,7 +436,7 @@ std::string FileUtils::loadText(const Path &path)
 {
     uint64 size = fileSize(path);
     InputStreamHandle in = openInputStream(path);
-    if (size == 0 || !in)
+    if (size == 0 || !in || !isFile(path))
         return std::string();
 
     // Strip UTF-8 byte order mark if present (mostly a problem on


### PR DESCRIPTION
For some reason, the stat call on a directory returned a size, and opening an input stream also worked, which meant the json parser complained about being fed garbage data.