### PR TITLE
Fix file type filter of file dialog

### DIFF
--- a/src/editor/properties/TextureProperty.cpp
+++ b/src/editor/properties/TextureProperty.cpp
@@ -139,9 +139,9 @@ void TextureProperty::buildTexturePage(PropertySheet *sheet, BitmapTexture *tex)
 
     std::string path = (!tex->path() || tex->path()->empty()) ? "" : tex->path()->absolute().asString();
     sheet->addPathProperty(path, "File", _scene->path().absolute().asString(),
-            "Open bitmap...", "Image files (*.png;*.jpg;*.hdr;*.pfm;*.tga;*.bmp;*.psd;*.gif;*.pic;*.jpeg"
+            "Open bitmap...", "Image files (*.png *.jpg *.hdr *.pfm *.tga *.bmp *.psd *.gif *.pic *.jpeg"
 #if OPENEXR_AVAILABLE
-            ";*.exr"
+            " *.exr"
 #endif
             ")",
             [this, tex](const std::string &path) {


### PR DESCRIPTION
According to [the Qt docs](http://doc.qt.io/qt-5/qfiledialog.html#getOpenFileName), `;;` is used to separate between filter sets; the separator between extensions should simply be a whitespace.