### PR TITLE
Fix more file extension filters

### DIFF
--- a/src/editor/PreviewWindow.cpp
+++ b/src/editor/PreviewWindow.cpp
@@ -459,7 +459,7 @@ void PreviewWindow::addModel()
         nullptr,
         "Open file...",
         QString::fromStdString(dir.absolute().asString()),
-        "Mesh files (*.obj;*.json)"
+        "Mesh files (*.obj *.json)"
     );
 
     if (!file.isEmpty()) {


### PR DESCRIPTION
According to [the Qt docs](http://doc.qt.io/qt-5/qfiledialog.html#getOpenFileName), `;;` is used to separate between filter sets; the separator between extensions should simply be a whitespace.