### PR TITLE
Various small fixes discovered by building with GCC6

### DIFF
--- a/src/core/io/ImageIO.cpp
+++ b/src/core/io/ImageIO.cpp
@@ -255,7 +255,7 @@ static std::unique_ptr<float[]> loadExr(const Path &path, TexelConversion reques
             }
         }
     } else {
-        return false;
+        return nullptr;
     }
 
     file.setFrameBuffer(frameBuffer);

--- a/src/core/io/Scene.cpp
+++ b/src/core/io/Scene.cpp
@@ -488,13 +488,14 @@ bool Scene::addUnique(const std::shared_ptr<T> &o, std::vector<std::shared_ptr<T
 
 void Scene::addPrimitive(const std::shared_ptr<Primitive> &mesh)
 {
-    if (addUnique(mesh, _primitives))
+    if (addUnique(mesh, _primitives)) {
         for (int i = 0; i < mesh->numBsdfs(); ++i)
             addBsdf(mesh->bsdf(i));
         if (mesh->intMedium())
             addUnique(mesh->intMedium(), _media);
         if (mesh->extMedium())
             addUnique(mesh->extMedium(), _media);
+    }
 }
 
 void Scene::addBsdf(const std::shared_ptr<Bsdf> &bsdf)

--- a/src/thirdparty/embree/sys/stl/vector.h
+++ b/src/thirdparty/embree/sys/stl/vector.h
@@ -52,7 +52,10 @@ namespace embree
       }
       
       ~vector_t() {
-        if (t) alignedFree(t); t = NULL;
+        if (t) {
+            alignedFree(t);
+            t = NULL;
+        }
       }
 
       inline bool empty() const { return m_size == 0; }


### PR DESCRIPTION
:heart: `-Wmisleading-indentation`

Have not run these yet because I haven't bothered building gcc-libs from SVN, so if someone could make sure I didn't break everything that'd be great. But it does compile, and the changes are fairly small.