### PR TITLE
Make output buffers write in output-directory

### DIFF
--- a/src/core/cameras/OutputBufferSettings.hpp
+++ b/src/core/cameras/OutputBufferSettings.hpp
@@ -23,6 +23,7 @@ class OutputBufferSettings : public JsonSerializable
     OutputBufferType _type;
     Path _ldrOutputFile;
     Path _hdrOutputFile;
+    Path _outputDirectory;
     bool _twoBufferVariance;
     bool _sampleVariance;
 
@@ -92,6 +93,14 @@ public:
         return result;
     }
 
+    void setOutputDirectory(const Path &directory)
+    {
+        _outputDirectory = directory;
+
+        _ldrOutputFile.setWorkingDirectory(_outputDirectory);
+        _hdrOutputFile.setWorkingDirectory(_outputDirectory);
+    }
+
     void setType(OutputBufferType type)
     {
         _type = type;
@@ -126,6 +135,7 @@ public:
     {
         return _ldrOutputFile;
     }
+
 };
 
 }

--- a/src/core/renderer/RendererSettings.hpp
+++ b/src/core/renderer/RendererSettings.hpp
@@ -119,7 +119,10 @@ public:
         _outputFile        .setWorkingDirectory(_outputDirectory);
         _hdrOutputFile     .setWorkingDirectory(_outputDirectory);
         _varianceOutputFile.setWorkingDirectory(_outputDirectory);
-        _resumeRenderFile.setWorkingDirectory(_outputDirectory);
+        _resumeRenderFile  .setWorkingDirectory(_outputDirectory);
+
+        for (auto &b : _outputs)
+            b.setOutputDirectory(_outputDirectory);
     }
 
     const Path &outputFile() const


### PR DESCRIPTION
Currently, output buffer files (HDR and LDR) are written to the directory that contains the scene description file. I think they should be written in the output-directory as well.