### PR TITLE
Add 'override' to some method declarations to silence compiler warnings.

### DIFF
--- a/src/core/bcsdfs/HairBcsdf.hpp
+++ b/src/core/bcsdfs/HairBcsdf.hpp
@@ -53,9 +53,9 @@ public:
     virtual void fromJson(const rapidjson::Value &v, const Scene &scene) override;
     rapidjson::Value toJson(Allocator &allocator) const override;
 
-    virtual Vec3f eval(const SurfaceScatterEvent &event) const;
-    virtual bool sample(SurfaceScatterEvent &event) const;
-    virtual float pdf(const SurfaceScatterEvent &event) const;
+    virtual Vec3f eval(const SurfaceScatterEvent &event) const override;
+    virtual bool sample(SurfaceScatterEvent &event) const override;
+    virtual float pdf(const SurfaceScatterEvent &event) const override;
 
     virtual void prepareForRender() override;
 };

--- a/src/core/io/ImageIO.cpp
+++ b/src/core/io/ImageIO.cpp
@@ -96,12 +96,12 @@ public:
         _in->seekg(0, std::ios_base::beg);
     }
 
-    virtual bool isMemoryMapped() const
+    virtual bool isMemoryMapped() const override
     {
         return false;
     }
 
-    virtual bool read(char c[/*n*/], int n)
+    virtual bool read(char c[/*n*/], int n) override
     {
         _in->read(c, n);
         if (!_in->good())

--- a/src/core/io/Scene.hpp
+++ b/src/core/io/Scene.hpp
@@ -85,8 +85,8 @@ public:
           std::shared_ptr<TextureCache> cache,
           std::shared_ptr<Camera> camera);
 
-    virtual void fromJson(const rapidjson::Value &v, const Scene &scene);
-    virtual rapidjson::Value toJson(Allocator &allocator) const;
+    virtual void fromJson(const rapidjson::Value &v, const Scene &scene) override;
+    virtual rapidjson::Value toJson(Allocator &allocator) const override;
 
     virtual void loadResources() override;
     virtual void saveResources() override;

--- a/src/core/primitives/Cube.hpp
+++ b/src/core/primitives/Cube.hpp
@@ -45,7 +45,7 @@ public:
     virtual bool samplePosition(PathSampleGenerator &sampler, PositionSample &sample) const override;
     virtual bool sampleDirection(PathSampleGenerator &sampler, const PositionSample &point, DirectionSample &sample) const override;
     virtual bool sampleDirect(uint32 threadIndex, const Vec3f &p, PathSampleGenerator &sampler, LightSample &sample) const override;
-    virtual float positionalPdf(const PositionSample &point) const;
+    virtual float positionalPdf(const PositionSample &point) const override;
     virtual float directionalPdf(const PositionSample &point, const DirectionSample &sample) const override;
     virtual float directPdf(uint32 threadIndex, const IntersectionTemporary &data,
             const IntersectionInfo &info, const Vec3f &p) const override;

--- a/src/core/primitives/Disk.hpp
+++ b/src/core/primitives/Disk.hpp
@@ -47,7 +47,7 @@ public:
     virtual bool samplePosition(PathSampleGenerator &sampler, PositionSample &sample) const override;
     virtual bool sampleDirection(PathSampleGenerator &sampler, const PositionSample &point, DirectionSample &sample) const override;
     virtual bool sampleDirect(uint32 threadIndex, const Vec3f &p, PathSampleGenerator &sampler, LightSample &sample) const override;
-    virtual float positionalPdf(const PositionSample &point) const;
+    virtual float positionalPdf(const PositionSample &point) const override;
     virtual float directionalPdf(const PositionSample &point, const DirectionSample &sample) const override;
     virtual float directPdf(uint32 threadIndex, const IntersectionTemporary &data,
             const IntersectionInfo &info, const Vec3f &p) const override;

--- a/src/core/primitives/InfiniteSphere.hpp
+++ b/src/core/primitives/InfiniteSphere.hpp
@@ -42,7 +42,7 @@ public:
     virtual bool samplePosition(PathSampleGenerator &sampler, PositionSample &sample) const override;
     virtual bool sampleDirection(PathSampleGenerator &sampler, const PositionSample &point, DirectionSample &sample) const override;
     virtual bool sampleDirect(uint32 threadIndex, const Vec3f &p, PathSampleGenerator &sampler, LightSample &sample) const override;
-    virtual float positionalPdf(const PositionSample &point) const;
+    virtual float positionalPdf(const PositionSample &point) const override;
     virtual float directionalPdf(const PositionSample &point, const DirectionSample &sample) const override;
     virtual float directPdf(uint32 threadIndex, const IntersectionTemporary &data,
             const IntersectionInfo &info, const Vec3f &p) const override;

--- a/src/core/primitives/InfiniteSphereCap.hpp
+++ b/src/core/primitives/InfiniteSphereCap.hpp
@@ -46,7 +46,7 @@ public:
     virtual bool samplePosition(PathSampleGenerator &sampler, PositionSample &sample) const override;
     virtual bool sampleDirection(PathSampleGenerator &sampler, const PositionSample &point, DirectionSample &sample) const override;
     virtual bool sampleDirect(uint32 threadIndex, const Vec3f &p, PathSampleGenerator &sampler, LightSample &sample) const override;
-    virtual float positionalPdf(const PositionSample &point) const;
+    virtual float positionalPdf(const PositionSample &point) const override;
     virtual float directionalPdf(const PositionSample &point, const DirectionSample &sample) const override;
     virtual float directPdf(uint32 threadIndex, const IntersectionTemporary &data,
             const IntersectionInfo &info, const Vec3f &p) const override;

--- a/src/core/primitives/Point.hpp
+++ b/src/core/primitives/Point.hpp
@@ -37,7 +37,7 @@ public:
     virtual bool samplePosition(PathSampleGenerator &sampler, PositionSample &sample) const override;
     virtual bool sampleDirection(PathSampleGenerator &sampler, const PositionSample &point, DirectionSample &sample) const override;
     virtual bool sampleDirect(uint32 threadIndex, const Vec3f &p, PathSampleGenerator &sampler, LightSample &sample) const override;
-    virtual float positionalPdf(const PositionSample &point) const;
+    virtual float positionalPdf(const PositionSample &point) const override;
     virtual float directionalPdf(const PositionSample &point, const DirectionSample &sample) const override;
     virtual float directPdf(uint32 threadIndex, const IntersectionTemporary &data,
             const IntersectionInfo &info, const Vec3f &p) const override;

--- a/src/core/primitives/Quad.hpp
+++ b/src/core/primitives/Quad.hpp
@@ -43,7 +43,7 @@ public:
     virtual bool samplePosition(PathSampleGenerator &sampler, PositionSample &sample) const override;
     virtual bool sampleDirection(PathSampleGenerator &sampler, const PositionSample &point, DirectionSample &sample) const override;
     virtual bool sampleDirect(uint32 threadIndex, const Vec3f &p, PathSampleGenerator &sampler, LightSample &sample) const override;
-    virtual float positionalPdf(const PositionSample &point) const;
+    virtual float positionalPdf(const PositionSample &point) const override;
     virtual float directionalPdf(const PositionSample &point, const DirectionSample &sample) const override;
     virtual float directPdf(uint32 threadIndex, const IntersectionTemporary &data,
             const IntersectionInfo &info, const Vec3f &p) const override;

--- a/src/core/primitives/Skydome.hpp
+++ b/src/core/primitives/Skydome.hpp
@@ -56,7 +56,7 @@ public:
     virtual bool samplePosition(PathSampleGenerator &sampler, PositionSample &sample) const override;
     virtual bool sampleDirection(PathSampleGenerator &sampler, const PositionSample &point, DirectionSample &sample) const override;
     virtual bool sampleDirect(uint32 threadIndex, const Vec3f &p, PathSampleGenerator &sampler, LightSample &sample) const override;
-    virtual float positionalPdf(const PositionSample &point) const;
+    virtual float positionalPdf(const PositionSample &point) const override;
     virtual float directionalPdf(const PositionSample &point, const DirectionSample &sample) const override;
     virtual float directPdf(uint32 threadIndex, const IntersectionTemporary &data,
             const IntersectionInfo &info, const Vec3f &p) const override;

--- a/src/core/primitives/Sphere.hpp
+++ b/src/core/primitives/Sphere.hpp
@@ -42,7 +42,7 @@ public:
     virtual bool samplePosition(PathSampleGenerator &sampler, PositionSample &sample) const override;
     virtual bool sampleDirection(PathSampleGenerator &sampler, const PositionSample &point, DirectionSample &sample) const override;
     virtual bool sampleDirect(uint32 threadIndex, const Vec3f &p, PathSampleGenerator &sampler, LightSample &sample) const override;
-    virtual float positionalPdf(const PositionSample &point) const;
+    virtual float positionalPdf(const PositionSample &point) const override;
     virtual float directionalPdf(const PositionSample &point, const DirectionSample &sample) const override;
     virtual float directPdf(uint32 threadIndex, const IntersectionTemporary &data,
             const IntersectionInfo &info, const Vec3f &p) const override;

--- a/src/core/primitives/TriangleMesh.hpp
+++ b/src/core/primitives/TriangleMesh.hpp
@@ -88,7 +88,7 @@ public:
             DirectionSample &sample) const override final;
     virtual bool sampleDirect(uint32 threadIndex, const Vec3f &p, PathSampleGenerator &sampler,
             LightSample &sample) const override;
-    virtual float positionalPdf(const PositionSample &point) const;
+    virtual float positionalPdf(const PositionSample &point) const override;
     virtual float directionalPdf(const PositionSample &point, const DirectionSample &sample) const override;
     virtual float directPdf(uint32 threadIndex, const IntersectionTemporary &data,
             const IntersectionInfo &info, const Vec3f &p) const override;

--- a/src/core/sampling/UniformPathSampler.hpp
+++ b/src/core/sampling/UniformPathSampler.hpp
@@ -20,15 +20,15 @@ public:
     {
     }
 
-    virtual void startPath(uint32 /*pixelId*/, uint32 /*sample*/)
+    virtual void startPath(uint32 /*pixelId*/, uint32 /*sample*/) override
     {
     }
 
-    virtual void saveState(OutputStreamHandle &out)
+    virtual void saveState(OutputStreamHandle &out) override
     {
         _sampler.saveState(out);
     }
-    virtual void loadState(InputStreamHandle &in)
+    virtual void loadState(InputStreamHandle &in) override
     {
         _sampler.loadState(in);
     }


### PR DESCRIPTION
(clang on OSX warns if some virtual method overrides are marked with the
'override' qualifier but not all are.)