### PR TITLE
Fix Linux data path location

### DIFF
--- a/src/core/io/FileUtils.cpp
+++ b/src/core/io/FileUtils.cpp
@@ -416,7 +416,7 @@ Path FileUtils::getDataPath()
         return std::move(execPath);
     return Path(INSTALL_PREFIX)/"data";
 #else
-    Path execPath = getExecutablePath().parent().parent()/"share/tungsten";
+    Path execPath = getExecutablePath().parent()/"share/tungsten";
     if (execPath.exists())
         return std::move(execPath);
     return Path(INSTALL_PREFIX)/"share/tungsten";


### PR DESCRIPTION
Apparently there was one `.parent()` too many, causing tungsten to search for `build/share/` instead of `build/debug/share/`. Fixes issue #33.