### PR TITLE
fix bumpMap convert

### DIFF
--- a/src/core/io/ObjLoader.cpp
+++ b/src/core/io/ObjLoader.cpp
@@ -302,7 +302,7 @@ std::shared_ptr<Bsdf> ObjLoader::convertObjMaterial(const ObjMaterial &mat)
             result = std::make_shared<TransparencyBsdf>(texture, result);
     }
     if (mat.hasBumpMap()) {
-        PathPtr path = std::make_shared<Path>(mat.alphaMap);
+        PathPtr path = std::make_shared<Path>(mat.bumpMap);
         path->freezeWorkingDirectory();
 
         auto texture = _textureCache->fetchTexture(path, TexelConversion::REQUEST_AVERAGE);


### PR DESCRIPTION
In ObjLoader.cpp `std::shared_ptr<Bsdf> ObjLoader::convertObjMaterial(const ObjMaterial &mat)`:

line 305 `PathPtr path = std::make_shared<Path>(mat.alphaMap);` should be `PathPtr path = std::make_shared<Path>(mat.bumpMap);`
