### PR TITLE
Fix nearest-neighbor interpolation of cached reconstruction filter

### DIFF
--- a/src/core/cameras/ReconstructionFilter.hpp
+++ b/src/core/cameras/ReconstructionFilter.hpp
@@ -209,7 +209,7 @@ public:
 
     inline float evalApproximate(float x) const
     {
-        return _filter[min(int(std::abs(x*_invBinSize)), RFILTER_RESOLUTION)];
+        return _filter[min(int(std::abs(x*_invBinSize) + 0.5f), RFILTER_RESOLUTION)];
     }
 
     float width() const


### PR DESCRIPTION
Hi Benedikt!

I was implementing film and reconstruction functionality in my renderer and I learned a lot from your implementation. I think that I stumbled upon a very tiny problem in your implementation that can have a noticeable effect on the result however.

When you retrieve the cached filter value, you effectively floor the continuous array index (via int cast) rather than rounding it to the closest integer. This will pick the "wrong" value (i.e. not the nearest neighbor) about 50% of the time as shown in the illustration below.

![](https://user-images.githubusercontent.com/15798094/157663592-d9dacba3-b7a4-4860-a0fa-b7eda04abb54.svg)

Since we are dealing with positive values, shifting the continuous index to the left by adding 0.5 before flooring is enough to achieve rounding. Here's a comparison between direct filter evaluation as reference, floor and round (using the Lanczos filter):

![diff](https://user-images.githubusercontent.com/15798094/157663680-34635aba-1f0d-4bb6-b621-cd206bc80823.svg)

I removed the normalization of `_filter` to achieve the same intended filter for these comparisons, since direct evaluation is not normalized.