### PR TITLE
Fixed un-initialized BSDF component bug in MixedBsdf.cpp

### DIFF
--- a/src/core/bsdfs/MixedBsdf.cpp
+++ b/src/core/bsdfs/MixedBsdf.cpp
@@ -132,6 +132,8 @@ float MixedBsdf::pdf(const SurfaceScatterEvent &event) const
 void MixedBsdf::prepareForRender()
 {
     _lobes = BsdfLobes(_bsdf0->lobes(), _bsdf1->lobes());
+    _bsdf0->prepareForRender();
+    _bsdf1->prepareForRender();
 }
 
 }


### PR DESCRIPTION
Hi, Benedikt!

I am working on this renderer and I think I found a bug. In line 132-135 of `src/core/bsdfs/MixedBsdf.cpp`

```c++
void MixedBsdf::prepareForRender()
{
    _lobes = BsdfLobes(_bsdf0->lobes(), _bsdf1->lobes());
}

```

`prepareForRender` is only called for this class, yet we should also call the `prepareForRender` method for its components (bsdf0 and bsdf1). This could be serious, since most BSDFs requires `prepareForRender` to compute the correct inputs.

Here is an example (the actual problem I encountered):

- bsdf0 is `RoughPlasticBsdf`
- bsdf1 is `DiffuseTransmissionBsdf`

For `RoughPlasticBsdf`, since the `prepareForRender` method is never called: `_substrateWeight ` is 0, so I am having unexpected output for the whole afternoon) and `printf` is not called, therefore, no terminal output.

```c++
_scaledSigmaA = _thickness*_sigmaA;
_avgTransmittance = std::exp(-2.0f*_scaledSigmaA.avg());
_substrateWeight = _albedo->average().avg();
printf("`RoughPlasticBsdf` Prepare for render: %f\n", _substrateWeight);
_diffuseFresnel = Fresnel::computeDiffuseFresnel(_ior, 1000000);
```

The proposed fix (rather simple):

```c++
void MixedBsdf::prepareForRender()
{
    _lobes = BsdfLobes(_bsdf0->lobes(), _bsdf1->lobes());
    // manually call the method:
    _bsdf0->prepareForRender();
    _bsdf1->prepareForRender();
}

```

Terminal output before fixing:

```
Loading scene '..\..\data\example-scenes\plant\convert.json'...
`prepareForRender` called for the mixed BSDF.
// Nothing then
```

After fixing:

```
Loading scene '..\..\data\example-scenes\plant\convert.json'...
`prepareForRender` called for the mixed BSDF.
`RoughPlasticBsdf` Prepare for render: 0.403922
```

Rendering result before and after fixing this bug. I guess it is a well-hidden bug, since I won't call the figure 'incorrect' before fixing. However, when I need the diffuse substrate but it is missing, I know there should be something wrong:

| before fixing | after fixing |
| ------------- | ------------ |
|![darker-before-fix](https://github.com/user-attachments/assets/fa96ef2c-d082-4caa-95bc-9e4139660782)|![after-fix](https://github.com/user-attachments/assets/acd2ac2b-7c25-4113-9af2-4029c40c45f0)|








